### PR TITLE
Gyp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ config_sync_test.json
 config_semi_test.json
 !src/results/.gitkeep
 !src/data/.gitkeep
+wandb/*

--- a/src/utils/Tools.py
+++ b/src/utils/Tools.py
@@ -14,7 +14,7 @@ def generate_stale_list(step, shuffle, n):
         for j in range(n[i]):
             while True:
                 s = random.randint(bound, bound + step)
-                if s != 0:
+                if s != bound:
                     break
             stale_list.append(s)
         bound += step


### PR DESCRIPTION
fix bound bug when generating random stale values ​​within a certain step.
